### PR TITLE
Handle `to_date` as `end of the date` in default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's a Slack bot to encourage us KPT retrospect.
 
 `@bot-name summary 2016/11/01 2016/11/30`
 
-The bot gathers KPTs you posted from 2016/11/01 and 2016/11/30 from history of a channel you called the bot.
+The bot gathers KPTs you posted from `2016/11/01 00:00` to `2016/11/30 23:59:59:999` from history of a channel you called the bot.
 
 ## Why not use another tool?
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ controller.hears("^summary (.+)",["direct_message","direct_mention","mention"], 
 
   // `latest` is optional parameter, and its default value is `now`.
   if (to_date) {
-    params.latest = new Date(to_date) / 1000
+    // When the given date is formatted as `2017/1/5`, it will be handled as `End time of the 2017/01/05`
+    to_time = /^\d+\/\d{1,2}\/\d{1,2}$/.test(to_date) ? (to_date + " 23:59:59:999" ) : to_date
+    params.latest = new Date(to_time) / 1000
   }
 
   let users;


### PR DESCRIPTION
Sounds useful to me.