### PR TITLE
Consider timezone and fetch history with `end_of_date`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ It's a Slack bot to encourage us KPT retrospect.
 
 ### Sample
 
-`@bot-name summary 2016/11/01 2016/11/30`
+`@bot-name summary 2016-11-01 2016-11-30`
 
-The bot gathers KPTs you posted from 2016/11/01 and 2016/11/30 from history of a channel you called the bot.
+The bot gathers KPTs you posted from 2016-11-01 and 2016-11-30 from history of a channel you called the bot.
 
 ## Why not use another tool?
 
@@ -33,7 +33,7 @@ Actually, there are many tools to do it, but most of them are not for "daily use
 
 We think of good ideas anytime we live. To memoize them, you open your laptop and start the app or web site to record your ideas. If you're out and do not have a good device to do it... Ugh, that's tiresome.
 
-Slack is now our "daily use" tool and their is less barriars to prevent us to track our KPTs.
+Slack is now our "daily use" tool and their is less barriers to prevent us to track our KPTs.
 
 ## Develop
 

--- a/index.js
+++ b/index.js
@@ -31,13 +31,16 @@ bot.startRTM(function(err, bot, payload) {
 /*
    This KPI bot waits for you to call him. Here is sample usage.
 
-   Format: @bot-name summary $from_date $to_date
+   Format:
+     @bot-name summary $from_date $to_date
      - from_date: Required. Start of time range of messages.
      - to_date:   Optional. End of time range of messages.
-   Sample: @bot-name 2016-11-01 2016-11-30
 
-   The bot gathers KPTs you posted between 2016-11-01 and 2016-11-30
-   from history of a channel you called the bot.
+   Sample:
+     @bot-name 2016-11-01 2016-11-30
+
+     The bot gathers KPTs you posted 2016-11-01 00:00:00 to 2016-11-30 23:59:59 in your timezone
+     from history of a channel you called the bot.
 
    ```
    K
@@ -90,11 +93,16 @@ controller.hears("^summary (.+)",["direct_message","direct_mention","mention"], 
 controller.hears("^((?!summary).)*$",["direct_message","direct_mention","mention"], (bot, message) => {
   const reply = `
 Sorry, I can't understand the order. :cry: Can you try again?
-Format: @bot-name summary $from_date $to_date
- - from_date: Required. Start of time range of messages.
- - to_date:   Optional. End of time range of messages.
-Sample: @bot-name summary 2016-11-01 2016-11-30
-`
+
+Format:
+  @bot-name summary $from_date $to_date
+  - from_date: Required. Start of time range of messages.
+  - to_date:   Optional. End of time range of messages.
+
+Sample:
+  @bot-name summary 2016-11-01 2016-11-30
+  @bot-name summary 2016-11-01
+`;
   bot.reply(message, reply);
 });
 

--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ bot.startRTM(function(err, bot, payload) {
    Format: @bot-name summary $from_date $to_date
      - from_date: Required. Start of time range of messages.
      - to_date:   Optional. End of time range of messages.
-   Sample: @bot-name 2016/11/01 2016/11/30
+   Sample: @bot-name 2016-11-01 2016-11-30
 
-   The bot gathers KPTs you posted between 2016/11/01 and 2016/11/30
+   The bot gathers KPTs you posted between 2016-11-01 and 2016-11-30
    from history of a channel you called the bot.
 
    ```
@@ -93,7 +93,7 @@ Sorry, I can't understand the order. :cry: Can you try again?
 Format: @bot-name summary $from_date $to_date
  - from_date: Required. Start of time range of messages.
  - to_date:   Optional. End of time range of messages.
-Sample: @bot-name summary 2016/11/01 2016/11/30
+Sample: @bot-name summary 2016-11-01 2016-11-30
 `
   bot.reply(message, reply);
 });

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ if (!slackBotToken) {
   process.exit(1);
 }
 
+const commonParams = {
+  token: slackBotToken,
+};
+
 const controller = Botkit.slackbot({
   debug: !!process.env.DEBUG
 });
@@ -45,33 +49,20 @@ bot.startRTM(function(err, bot, payload) {
    ```
  */
 controller.hears("^summary (.+)",["direct_message","direct_mention","mention"], (bot, message) => {
-  const [from_date, to_date] = message.match[1].split(' ');
-
-  let params = {
-    token: slackBotToken,
-    channel: message.channel,
-    oldest: (new Date(from_date) / 1000),
-    count: 1000,
-  }
-
-  // `latest` is optional parameter, and its default value is `now`.
-  if (to_date) {
-    params.latest = new Date(to_date) / 1000
-  }
-
   let users;
 
   const fetchUserListDone = (err, res) => {
-    checkError(err)
-    users = res.members
+    checkError(err);
+    users = res.members;
+
     // https://api.slack.com/methods/channels.history
-    bot.api.callAPI('channels.history', params, postSummary);
-  }
+    bot.api.callAPI('channels.history', paramsToFetchChannelHistory(message, users), postSummary);
+  };
 
   const postSummary = (err, res) => {
-    checkError(err)
+    checkError(err);
 
-    let result = { K: [], P: [], T: [] }
+    let result = { K: [], P: [], T: [] };
 
     for (const message of res.messages) {
       const matched = message.text.match(/^([KkPpTt])\s+(.+)/);
@@ -86,10 +77,10 @@ controller.hears("^summary (.+)",["direct_message","direct_mention","mention"], 
     }
 
     bot.reply(message, createSummary(result, users));
-  }
+  };
 
   // https://api.slack.com/methods/users.list
-  bot.api.callAPI('users.list', params, fetchUserListDone)
+  bot.api.callAPI('users.list', commonParams, fetchUserListDone)
 });
 
 /*
@@ -110,13 +101,13 @@ const checkError = (err) => {
   if (err) {
     throw new Error(`Slack API returns an error. error code: ${err}`);
   }
-}
+};
 
 const createSummary = (result, users) => {
   return ['K', 'P', 'T'].map((section) => {
     return `## ${section}\n\n${createSectionSummary(result[section], users)}\n`
   }).join('\n')
-}
+};
 
 const createSectionSummary = (elements, users) => {
   return elements.map(e => {
@@ -125,4 +116,20 @@ const createSectionSummary = (elements, users) => {
 
     return `- ${e.content} by ${username} ${reactions}`;
   }).join('\n')
-}
+};
+
+const paramsToFetchChannelHistory = (message) => {
+  const [from_date, to_date] = message.match[1].split(' ');
+
+  let params = Object.assign(commonParams, {
+    channel: message.channel,
+    oldest: (new Date(from_date) / 1000),
+    count: 1000,
+  });
+
+  // `latest` is optional parameter, and its default value is `now`.
+  if (to_date) {
+    params = Object.assign(params, {latest: new Date(to_date) / 1000});
+  }
+  return params;
+};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Botkit = require('botkit');
+const moment = require('moment-timezone');
 
 const slackBotToken = process.env.SLACK_BOT_TOKEN;
 
@@ -118,18 +119,22 @@ const createSectionSummary = (elements, users) => {
   }).join('\n')
 };
 
-const paramsToFetchChannelHistory = (message) => {
+const paramsToFetchChannelHistory = (message, users) => {
   const [from_date, to_date] = message.match[1].split(' ');
+
+  const userTimezone = users.find(u => u.id == message.user).tz;
 
   let params = Object.assign(commonParams, {
     channel: message.channel,
-    oldest: (new Date(from_date) / 1000),
+    oldest: moment.tz(from_date, userTimezone).unix(),
     count: 1000,
   });
 
   // `latest` is optional parameter, and its default value is `now`.
   if (to_date) {
-    params = Object.assign(params, {latest: new Date(to_date) / 1000});
+    params = Object.assign(params, {
+      latest: moment.tz(to_date, userTimezone).endOf('day').unix(),
+    });
   }
   return params;
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">= 6.0"
   },
   "dependencies": {
-    "botkit": "^0.4.3"
+    "botkit": "^0.4.3",
+    "moment-timezone": "^0.5.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,7 +780,13 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.10.3, moment@2.x.x:
+moment-timezone:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.11.tgz#9b76c03d8ef514c7e4249a7bbce649eed39ef29f"
+  dependencies:
+    moment ">= 2.6.0"
+
+moment@^2.10.3, "moment@>= 2.6.0", moment@2.x.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 


### PR DESCRIPTION
Addresses:
- https://github.com/ohbarye/kpt-bot/issues/9
- https://github.com/ohbarye/kpt-bot/pull/14

```
@bot-name 2016-11-01 2016-11-30
```

With this command, bots gather comments posted 2016-11-01 00:00:00 to 2016-11-30 23:59:59 in user's timezone.
