### PR TITLE
$from_date parameter defaults to the beginning of the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Slack is now our "daily use" tool and there are fewer barriers to prevent us to 
 ```sh
 $ git clone git@github.com:ohbarye/kpt-bot.git
 $ npm install -g yarn && yarn
-$ SLACK_BOT_TOKEN=your-slack-bot-token node index.js
+$ SLACK_BOT_TOKEN=your-slack-bot-token yarn start
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It's a Slack bot to encourage us KPT retrospect.
 
 `@bot-name summary $from_date $to_date`
 
-- from_date: Required. Start of a time range of messages.
+- from_date: Optional. Start of a time range of messages.
 - to_date:   Optional. End of a time range of messages.
 
 ### Sample

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ const createSummary = (result, users) => {
 
 const createSectionSummary = (elements, users) => {
   return elements.map(e => {
-    const username = users.find(u => u.id == e.userId).name;
+    const username = users.find(u => u.id === e.userId).name;
     const reactions = e.reactions.map(r => ` :${r.name}: `.repeat(r.count)).join('');
 
     return `- ${e.content} by ${username} ${reactions}`;
@@ -134,7 +134,7 @@ const createSectionSummary = (elements, users) => {
 const paramsToFetchChannelHistory = (message, users) => {
   const [from_date, to_date] = message.match[1].split(' ');
 
-  const userTimezone = users.find(u => u.id == message.user).tz;
+  const userTimezone = users.find(u => u.id === message.user).tz;
 
   let params = Object.assign(commonParams, {
     channel: message.channel,

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ Sorry, I can't understand the order. :cry: Can you try again?
 
 Format:
   @bot-name summary $from_date $to_date
-  - from_date: Required. Start of time range of messages.
+  - from_date: Optional. Start of time range of messages.
   - to_date:   Optional. End of time range of messages.
 
 Sample:

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ bot.startRTM(function(err, bot, payload) {
    - How about going lunch? :smile:
    ```
  */
-controller.hears("^summary (.+)",["direct_message","direct_mention","mention"], (bot, message) => {
+controller.hears("^summary ?(.+)?",["direct_message","direct_mention","mention"], (bot, message) => {
   let users;
 
   const fetchUserListDone = (err, res) => {
@@ -131,8 +131,22 @@ const createSectionSummary = (elements, users) => {
   }).reverse().join('\n')
 };
 
+const parseGivenDates = (message) => {
+  if (message.match[1]) {
+    // If both `from_date and `to_date` are given, or `from_date` is given
+    return message.match[1].split(' ');
+  } else {
+    // If none is given
+    const currentUnixTime = moment().unix();
+    const currentTime = moment(currentUnixTime * 1000);
+    const from_date = currentTime.tz('Asia/Tokyo').startOf('day').unix();
+
+    return [from_date, undefined];
+  }
+};
+
 const paramsToFetchChannelHistory = (message, users) => {
-  const [from_date, to_date] = message.match[1].split(' ');
+  const [from_date, to_date] = parseGivenDates(message);
 
   const userTimezone = users.find(u => u.id === message.user).tz;
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const commonParams = {
 };
 
 const controller = Botkit.slackbot({
-  debug: !!process.env.DEBUG
+  debug: !!process.env.DEBUG,
+  stats_optout: true
 });
 
 const bot = controller.spawn({

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "node": ">= 6.0"
   },
+  "scripts": {
+    "start": "node index.js"
+  },
   "dependencies": {
     "botkit": "^0.6.6",
     "moment-timezone": "^0.5.14"


### PR DESCRIPTION
## Issue
https://github.com/ohbarye/kpt-bot/issues/26

## Overview

With this PR, `kpt-bot` will get an ability that it can run without `$from_date` parameter. When we just say `@kpt-bot summary`, the bot recognizes `$from_date` is the beginning of the day.
